### PR TITLE
Fix error caused when the dataset has a cross dataset referenced and add button to the referenced dataset

### DIFF
--- a/src/tools/schemaVisualizerTool/Field.tsx
+++ b/src/tools/schemaVisualizerTool/Field.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import {CardTone, Stack, Flex, Card, Text, Code} from '@sanity/ui'
+import {CardTone, Stack, Flex, Card, Text, Code, Button} from '@sanity/ui'
 import {ObjectSchemaType, SchemaType} from 'sanity'
+import {LinkIcon} from '@sanity/icons'
 
 import Arrows from './Arrows'
 
@@ -59,7 +60,7 @@ export default function Field(props: FieldProps) {
   const isSlug = type.name === `slug`
 
   // Hide system fields and their children
-  if (type.name.startsWith(`sanity.`)) {
+  if (type.name?.startsWith(`sanity.`)) {
     return null
   }
 
@@ -74,11 +75,12 @@ export default function Field(props: FieldProps) {
           onMouseEnter={() => setCardTone('positive')}
           onMouseLeave={() => setCardTone('default')}
         >
-          <Flex justify="space-between" gap={3} align="flex-end">
+          <Flex justify="space-between" gap={3} align={type.name === 'crossDatasetReference' ? "center" : "flex-end"}>
             <Text size={isSmall ? 1 : 2}>{title || name}</Text>
             {showName ? (
               <Code size={isSmall ? 0 : 1}>{isPortableText ? `portableText` : type.name}</Code>
             ) : null}
+            {type.name === 'crossDatasetReference' && <a style={{cursor: `pointer`}} href={`/${type.dataset}/visualizer`}><Button fontSize={[1]} icon={LinkIcon} padding={[2]} /></a>}
             {referenceTypes.length > 0 ? <Arrows types={referenceTypes} path={newPath} /> : null}
           </Flex>
         </Card>


### PR DESCRIPTION
I was getting this error only when my dataset had a cross dataset reference:
<img width="599" alt="Screenshot 2023-06-27 at 14 41 34" src="https://github.com/SimeonGriggs/sanity-plugin-schema-visualizer/assets/1581912/b93b510d-dad9-421f-a849-428f8e82c957">

I'm getting a typescript error for `type.dataset` on line 83 of Field.tsx.  Not sure how to fix it because (in my little typescript experience) it looks like the types are coming from `ObjectSchemaType`, which are being imported from `sanity`.

Here is an image of how the link to the other dataset looks

<img width="690" alt="Screenshot 2023-06-27 at 15 50 03" src="https://github.com/SimeonGriggs/sanity-plugin-schema-visualizer/assets/1581912/cbb4a69e-5e22-4d1d-b3c5-20b94fb92dba">
